### PR TITLE
updated readme - fixed problems with the build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+WIsH
+build
+
+# CMAKE
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake

--- a/README.md
+++ b/README.md
@@ -7,16 +7,32 @@ WIsH is licensed under the General Public License (see the LICENSE file). Copyri
 
 * WIsH can identify bacterial hosts from metagenomic data, keeping good accuracy even on smaller contigs.
 * version 1.0
-* [Availabity](https://bitbucket.org/ClovisG/wish)
+* [Availabity](git@github.com:soedinglab/WIsH.git)
 
 ### How do I get set up? ###
 
 #### Installation: ####
 
+##### Linux: #####
 ```
 #!bash
-git clone git@bitbucket.org:ClovisG/wish.git
-cd wish
+git clone git@github.com:soedinglab/WIsH.git
+cd WIsH
+cmake .
+make
+```
+
+##### MacOS #####
+Compiling with OpenMP support on MacOS requires a recent gcc compiler. You can get gcc from [homebrew](https://brew.sh/).
+
+```
+#!bash
+brew install gcc@6
+export CC=gcc-6
+export CXX=g++-6
+
+git clone git@github.com:soedinglab/WIsH.git
+cd WIsH
 cmake .
 make
 ```
@@ -68,4 +84,4 @@ hist(predictions$V3)
 
 ### Troubleshooting - Bug reports ###
 
-* Please contact clovis.galiez@mpibpc.mpg.de
+* Please open a github issue or contact clovis.galiez@mpibpc.mpg.de

--- a/README.md.in
+++ b/README.md.in
@@ -7,16 +7,32 @@ WIsH is licensed under the General Public License (see the LICENSE file). Copyri
 
 * WIsH can identify bacterial hosts from metagenomic data, keeping good accuracy even on smaller contigs.
 * version @WIsH_VERSION_MAJOR@.@WIsH_VERSION_MINOR@
-* [Availabity](https://bitbucket.org/ClovisG/wish)
+* [Availabity](git@github.com:soedinglab/WIsH.git)
 
 ### How do I get set up? ###
 
 #### Installation: ####
 
+##### Linux: #####
 ```
 #!bash
-git clone git@bitbucket.org:ClovisG/wish.git
-cd wish
+git clone git@github.com:soedinglab/WIsH.git
+cd WIsH
+cmake .
+make
+```
+
+##### MacOS #####
+Compiling with OpenMP support on MacOS requires a recent gcc compiler. You can get gcc from [homebrew](https://brew.sh/).
+
+```
+#!bash
+brew install gcc@6
+export CC=gcc-6
+export CXX=g++-6
+
+git clone git@github.com:soedinglab/WIsH.git
+cd WIsH
 cmake .
 make
 ```
@@ -68,4 +84,4 @@ hist(predictions$V3)
 
 ### Troubleshooting - Bug reports ###
 
-* Please contact clovis.galiez@mpibpc.mpg.de
+* Please open a github issue or contact clovis.galiez@mpibpc.mpg.de

--- a/main.cpp
+++ b/main.cpp
@@ -11,9 +11,6 @@
 #include "mm.h"
 #include "main.h"
 
-//#define OPENMP
-
-
 #ifdef OPENMP
     #include <omp.h>
 #endif

--- a/mm.cpp
+++ b/mm.cpp
@@ -182,7 +182,7 @@ int mm::read(std::string modelFile)
         return -1;
         
     fin.seekg(0,fin.end);
-    size_t sizep = fin.tellg() - sizeof(alpha) - sizeof(order);
+    size_t sizep = static_cast<unsigned long>(fin.tellg()) - sizeof(alpha) - sizeof(order);
     
     
     p = std::vector<double>(sizep / sizeof(double));


### PR DESCRIPTION
:tada:

* added instructions how to compile on MacOS
* removed `#define OPENMP` from main.h
* statically cast `fin.tellg()` from `std:fpos` to `static_cast<unsigned long>(fin.tellg())` to make it compile on clang. Should be somewhat safe, I guess?