### PR TITLE
Handle lower case nucleotides

### DIFF
--- a/mm.cpp
+++ b/mm.cpp
@@ -71,7 +71,7 @@ std::string mm::mapToAlphabet(std::string seq)
     std::string res;
     for (size_t i = 0 ; i < seq.size() ; i++)
     {
-        switch (seq[i]) {
+        switch (toupper(seq[i])) {
             case 'A':
                 res.push_back(0);
                 break;

--- a/mm.h
+++ b/mm.h
@@ -11,7 +11,7 @@
 #include <iostream>
 #include <fstream>
 #include <math.h>
-
+#include <ctype.h>
 
 class mm
 {


### PR DESCRIPTION
Not sure if you had a specific reason for ignoring lowercase nucleotides or not.  If you don't have one, then this will include them in the kmer counting.